### PR TITLE
[bug]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,80 +1,68 @@
 # Changelog for server.shared
 
-## [Unreleased](https://github.com/modbus2mqtt/server.shared/tree/HEAD)
+## [v0.13.14](https://github.com/volkmarnissen/server.shared/tree/v0.13.14) (2025-01-28)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.15...HEAD)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.12...v0.13.14)
 
-**Merged pull requests:**
+## [v0.13.12](https://github.com/volkmarnissen/server.shared/tree/v0.13.12) (2024-12-31)
 
-- Modbus Error Handling and Monitoring [\#1](https://github.com/modbus2mqtt/server.shared/pull/1) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.11...v0.13.12)
 
-## [v0.13.15](https://github.com/modbus2mqtt/server.shared/tree/v0.13.15) (2025-04-14)
+## [v0.13.11](https://github.com/volkmarnissen/server.shared/tree/v0.13.11) (2024-12-30)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.14...v0.13.15)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.10...v0.13.11)
 
-## [v0.13.14](https://github.com/modbus2mqtt/server.shared/tree/v0.13.14) (2025-01-28)
+## [v0.13.10](https://github.com/volkmarnissen/server.shared/tree/v0.13.10) (2024-12-22)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.12...v0.13.14)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.9...v0.13.10)
 
-## [v0.13.12](https://github.com/modbus2mqtt/server.shared/tree/v0.13.12) (2024-12-31)
+## [v0.13.9](https://github.com/volkmarnissen/server.shared/tree/v0.13.9) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.11...v0.13.12)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.10.8...v0.13.9)
 
-## [v0.13.11](https://github.com/modbus2mqtt/server.shared/tree/v0.13.11) (2024-12-30)
+## [v0.10.8](https://github.com/volkmarnissen/server.shared/tree/v0.10.8) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.10...v0.13.11)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.8...v0.10.8)
 
-## [v0.13.10](https://github.com/modbus2mqtt/server.shared/tree/v0.13.10) (2024-12-22)
+## [v0.13.8](https://github.com/volkmarnissen/server.shared/tree/v0.13.8) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.9...v0.13.10)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.7...v0.13.8)
 
-## [v0.13.9](https://github.com/modbus2mqtt/server.shared/tree/v0.13.9) (2024-12-13)
+## [v0.13.7](https://github.com/volkmarnissen/server.shared/tree/v0.13.7) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.10.8...v0.13.9)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.6...v0.13.7)
 
-## [v0.10.8](https://github.com/modbus2mqtt/server.shared/tree/v0.10.8) (2024-12-11)
+## [v0.13.6](https://github.com/volkmarnissen/server.shared/tree/v0.13.6) (2024-10-22)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.8...v0.10.8)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.5...v0.13.6)
 
-## [v0.13.8](https://github.com/modbus2mqtt/server.shared/tree/v0.13.8) (2024-12-11)
+## [v0.13.5](https://github.com/volkmarnissen/server.shared/tree/v0.13.5) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.7...v0.13.8)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.4...v0.13.5)
 
-## [v0.13.7](https://github.com/modbus2mqtt/server.shared/tree/v0.13.7) (2024-11-14)
+## [v0.13.4](https://github.com/volkmarnissen/server.shared/tree/v0.13.4) (2024-10-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.6...v0.13.7)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.3...v0.13.4)
 
-## [v0.13.6](https://github.com/modbus2mqtt/server.shared/tree/v0.13.6) (2024-10-22)
+## [v0.13.3](https://github.com/volkmarnissen/server.shared/tree/v0.13.3) (2024-10-08)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.5...v0.13.6)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.1...v0.13.3)
 
-## [v0.13.5](https://github.com/modbus2mqtt/server.shared/tree/v0.13.5) (2024-10-16)
+## [v0.13.1](https://github.com/volkmarnissen/server.shared/tree/v0.13.1) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.4...v0.13.5)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.0...v0.13.1)
 
-## [v0.13.4](https://github.com/modbus2mqtt/server.shared/tree/v0.13.4) (2024-10-14)
+## [v0.13.0](https://github.com/volkmarnissen/server.shared/tree/v0.13.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.3...v0.13.4)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.12.0...v0.13.0)
 
-## [v0.13.3](https://github.com/modbus2mqtt/server.shared/tree/v0.13.3) (2024-10-08)
+## [v0.12.0](https://github.com/volkmarnissen/server.shared/tree/v0.12.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.1...v0.13.3)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.11.0...v0.12.0)
 
-## [v0.13.1](https://github.com/modbus2mqtt/server.shared/tree/v0.13.1) (2024-09-16)
+## [v0.11.0](https://github.com/volkmarnissen/server.shared/tree/v0.11.0) (2024-08-04)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.0...v0.13.1)
-
-## [v0.13.0](https://github.com/modbus2mqtt/server.shared/tree/v0.13.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.12.0...v0.13.0)
-
-## [v0.12.0](https://github.com/modbus2mqtt/server.shared/tree/v0.12.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.11.0...v0.12.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/server.shared/tree/v0.11.0) (2024-08-04)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,68 +1,80 @@
 # Changelog for server.shared
 
-## [v0.13.14](https://github.com/volkmarnissen/server.shared/tree/v0.13.14) (2025-01-28)
+## [Unreleased](https://github.com/modbus2mqtt/server.shared/tree/HEAD)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.12...v0.13.14)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.15...HEAD)
 
-## [v0.13.12](https://github.com/volkmarnissen/server.shared/tree/v0.13.12) (2024-12-31)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.11...v0.13.12)
+- Modbus Error Handling and Monitoring [\#1](https://github.com/modbus2mqtt/server.shared/pull/1) ([volkmarnissen](https://github.com/volkmarnissen))
 
-## [v0.13.11](https://github.com/volkmarnissen/server.shared/tree/v0.13.11) (2024-12-30)
+## [v0.13.15](https://github.com/modbus2mqtt/server.shared/tree/v0.13.15) (2025-04-14)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.10...v0.13.11)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.14...v0.13.15)
 
-## [v0.13.10](https://github.com/volkmarnissen/server.shared/tree/v0.13.10) (2024-12-22)
+## [v0.13.14](https://github.com/modbus2mqtt/server.shared/tree/v0.13.14) (2025-01-28)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.9...v0.13.10)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.12...v0.13.14)
 
-## [v0.13.9](https://github.com/volkmarnissen/server.shared/tree/v0.13.9) (2024-12-13)
+## [v0.13.12](https://github.com/modbus2mqtt/server.shared/tree/v0.13.12) (2024-12-31)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.10.8...v0.13.9)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.11...v0.13.12)
 
-## [v0.10.8](https://github.com/volkmarnissen/server.shared/tree/v0.10.8) (2024-12-11)
+## [v0.13.11](https://github.com/modbus2mqtt/server.shared/tree/v0.13.11) (2024-12-30)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.8...v0.10.8)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.10...v0.13.11)
 
-## [v0.13.8](https://github.com/volkmarnissen/server.shared/tree/v0.13.8) (2024-12-11)
+## [v0.13.10](https://github.com/modbus2mqtt/server.shared/tree/v0.13.10) (2024-12-22)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.7...v0.13.8)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.9...v0.13.10)
 
-## [v0.13.7](https://github.com/volkmarnissen/server.shared/tree/v0.13.7) (2024-11-14)
+## [v0.13.9](https://github.com/modbus2mqtt/server.shared/tree/v0.13.9) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.6...v0.13.7)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.10.8...v0.13.9)
 
-## [v0.13.6](https://github.com/volkmarnissen/server.shared/tree/v0.13.6) (2024-10-22)
+## [v0.10.8](https://github.com/modbus2mqtt/server.shared/tree/v0.10.8) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.5...v0.13.6)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.8...v0.10.8)
 
-## [v0.13.5](https://github.com/volkmarnissen/server.shared/tree/v0.13.5) (2024-10-16)
+## [v0.13.8](https://github.com/modbus2mqtt/server.shared/tree/v0.13.8) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.4...v0.13.5)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.7...v0.13.8)
 
-## [v0.13.4](https://github.com/volkmarnissen/server.shared/tree/v0.13.4) (2024-10-14)
+## [v0.13.7](https://github.com/modbus2mqtt/server.shared/tree/v0.13.7) (2024-11-14)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.3...v0.13.4)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.6...v0.13.7)
 
-## [v0.13.3](https://github.com/volkmarnissen/server.shared/tree/v0.13.3) (2024-10-08)
+## [v0.13.6](https://github.com/modbus2mqtt/server.shared/tree/v0.13.6) (2024-10-22)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.1...v0.13.3)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.5...v0.13.6)
 
-## [v0.13.1](https://github.com/volkmarnissen/server.shared/tree/v0.13.1) (2024-09-16)
+## [v0.13.5](https://github.com/modbus2mqtt/server.shared/tree/v0.13.5) (2024-10-16)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.0...v0.13.1)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.4...v0.13.5)
 
-## [v0.13.0](https://github.com/volkmarnissen/server.shared/tree/v0.13.0) (2024-08-16)
+## [v0.13.4](https://github.com/modbus2mqtt/server.shared/tree/v0.13.4) (2024-10-14)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.12.0...v0.13.0)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.3...v0.13.4)
 
-## [v0.12.0](https://github.com/volkmarnissen/server.shared/tree/v0.12.0) (2024-08-05)
+## [v0.13.3](https://github.com/modbus2mqtt/server.shared/tree/v0.13.3) (2024-10-08)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.11.0...v0.12.0)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.1...v0.13.3)
 
-## [v0.11.0](https://github.com/volkmarnissen/server.shared/tree/v0.11.0) (2024-08-04)
+## [v0.13.1](https://github.com/modbus2mqtt/server.shared/tree/v0.13.1) (2024-09-16)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.0...v0.13.1)
+
+## [v0.13.0](https://github.com/modbus2mqtt/server.shared/tree/v0.13.0) (2024-08-16)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.12.0...v0.13.0)
+
+## [v0.12.0](https://github.com/modbus2mqtt/server.shared/tree/v0.12.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.11.0...v0.12.0)
+
+## [v0.11.0](https://github.com/modbus2mqtt/server.shared/tree/v0.11.0) (2024-08-04)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.15",
       "license": "MIT",
       "dependencies": {
-        "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared#v0.10.11",
+        "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared",
         "mqtt": "^5.10.3"
       },
       "devDependencies": {
@@ -32,7 +32,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#f71e271848386477ef780cb246805b349e2eb50d",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#033bf13926a0d5bd148069eb3076cf71d5279188",
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.15",
       "license": "MIT",
       "dependencies": {
-        "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared",
+        "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared#v0.10.11",
         "mqtt": "^5.10.3"
       },
       "devDependencies": {
@@ -32,7 +32,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#033bf13926a0d5bd148069eb3076cf71d5279188",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#f71e271848386477ef780cb246805b349e2eb50d",
       "license": "MIT"
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared#v0.10.11",
+    "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared",
     "mqtt": "^5.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared",
+    "@modbus2mqtt/specification.shared": "file:../specification.shared",
     "mqtt": "^5.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared",
+    "@modbus2mqtt/specification.shared": "github:modbus2mqtt/specification.shared#v0.10.11",
     "mqtt": "^5.10.3"
   }
 }

--- a/src/Slave.ts
+++ b/src/Slave.ts
@@ -11,9 +11,7 @@ export class Slave {
     private slave: Islave,
     private mqttBaseTopic: string
   ) {
-    this.specification = undefined
   }
-  specification: Ispecification| undefined
   getStateTopic(): string {
     return this.getBaseTopic() + '/state/'
   }
@@ -101,16 +99,14 @@ export class Slave {
     return this.slave.slaveid
   }
   getEntityName(entityId:number): string | undefined {
-    if( !this.specification|| !this.specification.entities)
+    let spec = this.getSpecification()
+    if( !spec|| !spec.entities)
       return undefined
-    let e = this.specification.entities.find(e=>e.id==entityId)
+    let e = spec.entities.find(e=>e.id==entityId)
     return e?e.name:undefined
   }
   getName(): string | undefined {
     return this.slave.name
-  }
-  getIdentSpecification():IidentificationSpecification|undefined {
-    return this.slave.specification
   }
   getQos(): number | undefined {
     return this.slave.qos
@@ -131,13 +127,9 @@ export class Slave {
 
 
   getSpecification(): Ispecification | undefined {
-    return this.specification 
-  }
-
-  setSpecification(spec: Ispecification | undefined) {
-    if (this.slave) {
-      this.specification = spec
-    }
+    if (this.slave && this.slave.specification)
+      return this.slave.specification 
+    return undefined
   }
 
   getSpecificationId(): string | undefined {

--- a/src/Slave.ts
+++ b/src/Slave.ts
@@ -1,4 +1,4 @@
-import { IbaseSpecification, Ientity, ImodbusEntity, ImodbusSpecification, Ispecification } from '@modbus2mqtt/specification.shared'
+import { Ientity, IidentEntity, ImodbusEntity, ImodbusSpecification, Ispecification } from '@modbus2mqtt/specification.shared'
 import { IidentificationSpecification, Islave, PollModes } from './types'
 export interface IEntityCommandTopics {
   entityId: number
@@ -28,13 +28,13 @@ export class Slave {
   getTriggerPollTopic(): string {
     return this.getBaseTopic() + '/triggerPoll/'
   }
-  getEntityCommandTopic(entity?: Ientity): IEntityCommandTopics | undefined {
+  getEntityCommandTopic(entity?: IidentEntity): IEntityCommandTopics | undefined {
     let commandTopic: string | undefined = undefined
     let modbusCommandTopic: string | undefined = undefined
     if (entity)
       if (!entity.readonly) {
         commandTopic = this.getBaseTopic() + '/' + entity.mqttname + '/set/'
-        if (entity.converter.name == 'select') modbusCommandTopic = this.getBaseTopic() + '/' + entity.mqttname + '/set/modbus/'
+        // TODO user /set/ for select if (entity.converter == ) modbusCommandTopic = this.getBaseTopic() + '/' + entity.mqttname + '/set/'
         return {
           entityId: entity.id,
           commandTopic: commandTopic ? commandTopic : 'error',
@@ -86,7 +86,7 @@ export class Slave {
     for (let e of entities) {
       if (e.mqttname != undefined && e.mqttname.length > 0 && e.variableConfiguration == undefined) {
         o[e.mqttname] = e.mqttValue != undefined ? e.mqttValue : defaultValue
-        if (e.converter.name == 'select') {
+        if (e.converter == 'select') {
           if (o.modbusValues == undefined) o.modbusValues = {}
           if (e.modbusValue != undefined && e.modbusValue.length > 0) o.modbusValues[e.mqttname] = e.modbusValue[0]
         }
@@ -99,6 +99,12 @@ export class Slave {
   }
   getSlaveId(): number {
     return this.slave.slaveid
+  }
+  getEntityName(entityId:number): string | undefined {
+    if( !this.specification|| !this.specification.entities)
+      return undefined
+    let e = this.specification.entities.find(e=>e.id==entityId)
+    return e?e.name:undefined
   }
   getName(): string | undefined {
     return this.slave.name

--- a/src/Slave.ts
+++ b/src/Slave.ts
@@ -10,8 +10,7 @@ export class Slave {
     private busid: number,
     private slave: Islave,
     private mqttBaseTopic: string
-  ) {
-  }
+  ) {}
   getStateTopic(): string {
     return this.getBaseTopic() + '/state/'
   }
@@ -98,12 +97,11 @@ export class Slave {
   getSlaveId(): number {
     return this.slave.slaveid
   }
-  getEntityName(entityId:number): string | undefined {
+  getEntityName(entityId: number): string | undefined {
     let spec = this.getSpecification()
-    if( !spec|| !spec.entities)
-      return undefined
-    let e = spec.entities.find(e=>e.id==entityId)
-    return e?e.name:undefined
+    if (!spec || !spec.entities) return undefined
+    let e = spec.entities.find((e) => e.id == entityId)
+    return e ? e.name : undefined
   }
   getName(): string | undefined {
     return this.slave.name
@@ -125,10 +123,8 @@ export class Slave {
     return this.busid + 's' + this.slave.slaveid
   }
 
-
   getSpecification(): Ispecification | undefined {
-    if (this.slave && this.slave.specification)
-      return this.slave.specification 
+    if (this.slave && this.slave.specification) return this.slave.specification
     return undefined
   }
 

--- a/src/Slave.ts
+++ b/src/Slave.ts
@@ -1,5 +1,5 @@
 import { IbaseSpecification, Ientity, ImodbusEntity, ImodbusSpecification, Ispecification } from '@modbus2mqtt/specification.shared'
-import { Islave, PollModes } from './types'
+import { IidentificationSpecification, Islave, PollModes } from './types'
 export interface IEntityCommandTopics {
   entityId: number
   commandTopic: string
@@ -10,7 +10,10 @@ export class Slave {
     private busid: number,
     private slave: Islave,
     private mqttBaseTopic: string
-  ) {}
+  ) {
+    this.specification = undefined
+  }
+  specification: Ispecification| undefined
   getStateTopic(): string {
     return this.getBaseTopic() + '/state/'
   }
@@ -54,7 +57,7 @@ export class Slave {
   getCommandTopic(): string | undefined {
     let commandTopic: string | undefined = undefined
     let modbusCommandTopic: string | undefined = undefined
-    if (this.getSpecification()?.entities.find((e) => !e.readonly)) {
+    if (this.slave.specification?.entities.find((e) => !e.readonly)) {
       commandTopic = this.getBaseTopic() + '/set/'
       return commandTopic
     }
@@ -100,6 +103,9 @@ export class Slave {
   getName(): string | undefined {
     return this.slave.name
   }
+  getIdentSpecification():IidentificationSpecification|undefined {
+    return this.slave.specification
+  }
   getQos(): number | undefined {
     return this.slave.qos
   }
@@ -117,15 +123,14 @@ export class Slave {
     return this.busid + 's' + this.slave.slaveid
   }
 
+
   getSpecification(): Ispecification | undefined {
-    if (this.slave && this.slave.specification && (this.slave.specification as Ispecification).entities)
-      return this.slave.specification as Ispecification
-    return undefined
+    return this.specification 
   }
 
   setSpecification(spec: Ispecification | undefined) {
     if (this.slave) {
-      this.slave.specification = spec
+      this.specification = spec
     }
   }
 

--- a/src/httpConstants.ts
+++ b/src/httpConstants.ts
@@ -1,6 +1,6 @@
 export const enum apiUri {
   modbusSpecification = '/api/modbus/specification',
-  specsForSlaveId = '/api/specsForSlaveId',
+  specsDetection = '/api/specsDetection',
   specifications = '/api/specifications',
   specfication = '/api/specification',
   specficationContribute = '/api/specification/contribute',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,8 @@
 
 import {
   IdentifiedStates,
-  IidentEntity,
-  ImodbusSpecification,
-  Ispecification,
+  IimageAndDocumentUrl,
+  ImodbusEntity,
   ModbusRegisterType,
   SpecificationStatus,
 } from '@modbus2mqtt/specification.shared'

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface IRTUConnection {
   serialport: string
   baudrate: number
   timeout: number
+  tcpBridgePort?: number
 }
 export interface ITCPConnection {
   host: string
@@ -98,7 +99,6 @@ export interface IBus {
   busId: number
   connectionData: IModbusConnection
   slaves: Islave[]
-  tcpBridgePort?: number
 }
 export function getConnectionName(connection: IModbusConnection): string {
   if ((connection as IRTUConnection).baudrate) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface IBus {
   busId: number
   connectionData: IModbusConnection
   slaves: Islave[]
-  tcpBridgePort?:number
+  tcpBridgePort?: number
 }
 export function getConnectionName(connection: IModbusConnection): string {
   if ((connection as IRTUConnection).baudrate) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,7 @@ export interface Islave {
   name?: string
   pollInterval?: number
   pollMode?: PollModes
-  specification?: IbaseSpecification
+  specification?: IidentificationSpecification
   durationOfLongestModbusCall?: number
   modbusTimout?: number
   evalTimeout?: boolean
@@ -163,12 +163,16 @@ export interface Islave {
   modbusErrorsForSlave?:ImodbusErrorsForSlave[]
 }
 
+export interface IidentEntity {
+  id:number,
+  name?:string,
+  readonly:boolean,
+  mqttname:string
+}
 export interface IidentificationSpecification {
   filename: string
+  name?:string
   status: SpecificationStatus
-  entities: ImodbusEntity[]
-  files: IimageAndDocumentUrl[]
-  i18n: ISpecificationTexts[]
   identified: IdentifiedStates
-  configuredSlave?: Islave
+  entities: IidentEntity[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,7 @@
-
 import {
   IdentifiedStates,
   IidentEntity,
-  IimageAndDocumentUrl,
-  ImodbusEntity,
+  ImodbusSpecification,
   Ispecification,
   ModbusRegisterType,
   SpecificationStatus,
@@ -77,7 +75,7 @@ export interface Iconfiguration {
   httpport: number
   rootUrl?: string
   supervisor_host?: string
-  debugComponents?:string
+  debugComponents?: string
 }
 export enum AuthenticationErrors {
   EnvironmentVariableSecretNotSet = 1,
@@ -100,6 +98,7 @@ export interface IBus {
   busId: number
   connectionData: IModbusConnection
   slaves: Islave[]
+  tcpBridgePort?:number
 }
 export function getConnectionName(connection: IModbusConnection): string {
   if ((connection as IRTUConnection).baudrate) {
@@ -111,8 +110,8 @@ export function getConnectionName(connection: IModbusConnection): string {
   }
 }
 export interface ImodbusError {
-  entityId: number;
-  message: string;
+  entityId: number
+  message: string
 }
 export enum ModbusErrorStates {
   noerror,
@@ -121,7 +120,7 @@ export enum ModbusErrorStates {
   other,
   illegalfunctioncode,
   illegaladdress,
-  initialConnect
+  initialConnect,
 }
 
 export interface ImodbusAddress {
@@ -137,13 +136,14 @@ export enum ModbusTasks {
   poll,
   writeEntity,
   splitted,
-  initialConnect
+  initialConnect,
+  tcpBridge,
 }
 export interface ImodbusErrorsForSlave {
-  task:ModbusTasks,
-  date:number,
-  address:ImodbusAddress,
-  state:ModbusErrorStates
+  task: ModbusTasks
+  date: number
+  address: ImodbusAddress
+  state: ModbusErrorStates
 }
 export interface Islave {
   slaveid: number
@@ -160,11 +160,11 @@ export interface Islave {
   rootTopic?: string
   noDiscoverEntities?: number[]
   noDiscovery?: boolean
-  modbusErrorsForSlave?:ImodbusErrorsForSlave[]
+  modbusErrorsForSlave?: ImodbusErrorsForSlave[]
 }
 export interface IidentificationSpecification {
   filename: string
-  name?:string
+  name?: string
   status: SpecificationStatus
   identified: IdentifiedStates
   entities: IidentEntity[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 
 import {
   IdentifiedStates,
+  IidentEntity,
   IimageAndDocumentUrl,
   ImodbusEntity,
+  Ispecification,
   ModbusRegisterType,
   SpecificationStatus,
 } from '@modbus2mqtt/specification.shared'

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@
 import {
   IdentifiedStates,
   IidentEntity,
+  ImodbusSpecification,
+  Ispecification,
   ModbusRegisterType,
   SpecificationStatus,
 } from '@modbus2mqtt/specification.shared'
@@ -148,7 +150,7 @@ export interface Islave {
   name?: string
   pollInterval?: number
   pollMode?: PollModes
-  specification?: IidentificationSpecification
+  specification?: Ispecification
   durationOfLongestModbusCall?: number
   modbusTimout?: number
   evalTimeout?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,7 @@
 
 import {
-  ISpecificationTexts,
-  IbaseSpecification,
   IdentifiedStates,
-  IimageAndDocumentUrl,
-  ImodbusEntity,
+  IidentEntity,
   ModbusRegisterType,
   SpecificationStatus,
 } from '@modbus2mqtt/specification.shared'
@@ -161,13 +158,6 @@ export interface Islave {
   noDiscoverEntities?: number[]
   noDiscovery?: boolean
   modbusErrorsForSlave?:ImodbusErrorsForSlave[]
-}
-
-export interface IidentEntity {
-  id:number,
-  name?:string,
-  readonly:boolean,
-  mqttname:string
 }
 export interface IidentificationSpecification {
   filename: string


### PR DESCRIPTION
Fixed:
- Slave UI: Specification detection did not work.
- Error Handling: Too many restarts, to many error handling slowed detection down
- Slave UI: detect specifications for new Slaves only.
- Bus: Added support for TCP RTU bridge
- Slave UI: Load complete list of specifications before spec detection
- Modbus: Use same cache for a given busid even if the Bus was recreated