### PR TITLE
Enable Display and Input in Hex format for modbus Addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,93 +1,68 @@
 # Changelog for server.shared
 
-## [v0.13.18](https://github.com/modbus2mqtt/server.shared/tree/v0.13.18) (2025-09-03)
+## [v0.13.14](https://github.com/volkmarnissen/server.shared/tree/v0.13.14) (2025-01-28)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.17...v0.13.18)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.12...v0.13.14)
 
-## [v0.13.17](https://github.com/modbus2mqtt/server.shared/tree/v0.13.17) (2025-09-03)
+## [v0.13.12](https://github.com/volkmarnissen/server.shared/tree/v0.13.12) (2024-12-31)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.16...v0.13.17)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.11...v0.13.12)
 
-## [v0.13.16](https://github.com/modbus2mqtt/server.shared/tree/v0.13.16) (2025-09-03)
+## [v0.13.11](https://github.com/volkmarnissen/server.shared/tree/v0.13.11) (2024-12-30)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.15...v0.13.16)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.10...v0.13.11)
 
-**Merged pull requests:**
+## [v0.13.10](https://github.com/volkmarnissen/server.shared/tree/v0.13.10) (2024-12-22)
 
-- \[Feature\] Add number of processed calls to Modbus Status [\#6](https://github.com/modbus2mqtt/server.shared/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[Feature\] Add number of processed calls to Modbus Status [\#5](https://github.com/modbus2mqtt/server.shared/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
-- Add package.json github dependency again [\#4](https://github.com/modbus2mqtt/server.shared/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#3](https://github.com/modbus2mqtt/server.shared/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#2](https://github.com/modbus2mqtt/server.shared/pull/2) ([volkmarnissen](https://github.com/volkmarnissen))
-- Modbus Error Handling and Monitoring [\#1](https://github.com/modbus2mqtt/server.shared/pull/1) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.9...v0.13.10)
 
-## [v0.13.15](https://github.com/modbus2mqtt/server.shared/tree/v0.13.15) (2025-04-14)
+## [v0.13.9](https://github.com/volkmarnissen/server.shared/tree/v0.13.9) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.14...v0.13.15)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.10.8...v0.13.9)
 
-## [v0.13.14](https://github.com/modbus2mqtt/server.shared/tree/v0.13.14) (2025-01-28)
+## [v0.10.8](https://github.com/volkmarnissen/server.shared/tree/v0.10.8) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.12...v0.13.14)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.8...v0.10.8)
 
-## [v0.13.12](https://github.com/modbus2mqtt/server.shared/tree/v0.13.12) (2024-12-31)
+## [v0.13.8](https://github.com/volkmarnissen/server.shared/tree/v0.13.8) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.11...v0.13.12)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.7...v0.13.8)
 
-## [v0.13.11](https://github.com/modbus2mqtt/server.shared/tree/v0.13.11) (2024-12-30)
+## [v0.13.7](https://github.com/volkmarnissen/server.shared/tree/v0.13.7) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.10...v0.13.11)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.6...v0.13.7)
 
-## [v0.13.10](https://github.com/modbus2mqtt/server.shared/tree/v0.13.10) (2024-12-22)
+## [v0.13.6](https://github.com/volkmarnissen/server.shared/tree/v0.13.6) (2024-10-22)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.9...v0.13.10)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.5...v0.13.6)
 
-## [v0.13.9](https://github.com/modbus2mqtt/server.shared/tree/v0.13.9) (2024-12-13)
+## [v0.13.5](https://github.com/volkmarnissen/server.shared/tree/v0.13.5) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.10.8...v0.13.9)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.4...v0.13.5)
 
-## [v0.10.8](https://github.com/modbus2mqtt/server.shared/tree/v0.10.8) (2024-12-11)
+## [v0.13.4](https://github.com/volkmarnissen/server.shared/tree/v0.13.4) (2024-10-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.8...v0.10.8)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.3...v0.13.4)
 
-## [v0.13.8](https://github.com/modbus2mqtt/server.shared/tree/v0.13.8) (2024-12-11)
+## [v0.13.3](https://github.com/volkmarnissen/server.shared/tree/v0.13.3) (2024-10-08)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.7...v0.13.8)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.1...v0.13.3)
 
-## [v0.13.7](https://github.com/modbus2mqtt/server.shared/tree/v0.13.7) (2024-11-14)
+## [v0.13.1](https://github.com/volkmarnissen/server.shared/tree/v0.13.1) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.6...v0.13.7)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.0...v0.13.1)
 
-## [v0.13.6](https://github.com/modbus2mqtt/server.shared/tree/v0.13.6) (2024-10-22)
+## [v0.13.0](https://github.com/volkmarnissen/server.shared/tree/v0.13.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.5...v0.13.6)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.12.0...v0.13.0)
 
-## [v0.13.5](https://github.com/modbus2mqtt/server.shared/tree/v0.13.5) (2024-10-16)
+## [v0.12.0](https://github.com/volkmarnissen/server.shared/tree/v0.12.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.4...v0.13.5)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.11.0...v0.12.0)
 
-## [v0.13.4](https://github.com/modbus2mqtt/server.shared/tree/v0.13.4) (2024-10-14)
+## [v0.11.0](https://github.com/volkmarnissen/server.shared/tree/v0.11.0) (2024-08-04)
 
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.3...v0.13.4)
-
-## [v0.13.3](https://github.com/modbus2mqtt/server.shared/tree/v0.13.3) (2024-10-08)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.1...v0.13.3)
-
-## [v0.13.1](https://github.com/modbus2mqtt/server.shared/tree/v0.13.1) (2024-09-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.0...v0.13.1)
-
-## [v0.13.0](https://github.com/modbus2mqtt/server.shared/tree/v0.13.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.12.0...v0.13.0)
-
-## [v0.12.0](https://github.com/modbus2mqtt/server.shared/tree/v0.12.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.11.0...v0.12.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/server.shared/tree/v0.11.0) (2024-08-04)
-
-[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
+[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,68 +1,93 @@
 # Changelog for server.shared
 
-## [v0.13.14](https://github.com/volkmarnissen/server.shared/tree/v0.13.14) (2025-01-28)
+## [v0.13.18](https://github.com/modbus2mqtt/server.shared/tree/v0.13.18) (2025-09-03)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.12...v0.13.14)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.17...v0.13.18)
 
-## [v0.13.12](https://github.com/volkmarnissen/server.shared/tree/v0.13.12) (2024-12-31)
+## [v0.13.17](https://github.com/modbus2mqtt/server.shared/tree/v0.13.17) (2025-09-03)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.11...v0.13.12)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.16...v0.13.17)
 
-## [v0.13.11](https://github.com/volkmarnissen/server.shared/tree/v0.13.11) (2024-12-30)
+## [v0.13.16](https://github.com/modbus2mqtt/server.shared/tree/v0.13.16) (2025-09-03)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.10...v0.13.11)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.15...v0.13.16)
 
-## [v0.13.10](https://github.com/volkmarnissen/server.shared/tree/v0.13.10) (2024-12-22)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.9...v0.13.10)
+- \[Feature\] Add number of processed calls to Modbus Status [\#6](https://github.com/modbus2mqtt/server.shared/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[Feature\] Add number of processed calls to Modbus Status [\#5](https://github.com/modbus2mqtt/server.shared/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
+- Add package.json github dependency again [\#4](https://github.com/modbus2mqtt/server.shared/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#3](https://github.com/modbus2mqtt/server.shared/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#2](https://github.com/modbus2mqtt/server.shared/pull/2) ([volkmarnissen](https://github.com/volkmarnissen))
+- Modbus Error Handling and Monitoring [\#1](https://github.com/modbus2mqtt/server.shared/pull/1) ([volkmarnissen](https://github.com/volkmarnissen))
 
-## [v0.13.9](https://github.com/volkmarnissen/server.shared/tree/v0.13.9) (2024-12-13)
+## [v0.13.15](https://github.com/modbus2mqtt/server.shared/tree/v0.13.15) (2025-04-14)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.10.8...v0.13.9)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.14...v0.13.15)
 
-## [v0.10.8](https://github.com/volkmarnissen/server.shared/tree/v0.10.8) (2024-12-11)
+## [v0.13.14](https://github.com/modbus2mqtt/server.shared/tree/v0.13.14) (2025-01-28)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.8...v0.10.8)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.12...v0.13.14)
 
-## [v0.13.8](https://github.com/volkmarnissen/server.shared/tree/v0.13.8) (2024-12-11)
+## [v0.13.12](https://github.com/modbus2mqtt/server.shared/tree/v0.13.12) (2024-12-31)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.7...v0.13.8)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.11...v0.13.12)
 
-## [v0.13.7](https://github.com/volkmarnissen/server.shared/tree/v0.13.7) (2024-11-14)
+## [v0.13.11](https://github.com/modbus2mqtt/server.shared/tree/v0.13.11) (2024-12-30)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.6...v0.13.7)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.10...v0.13.11)
 
-## [v0.13.6](https://github.com/volkmarnissen/server.shared/tree/v0.13.6) (2024-10-22)
+## [v0.13.10](https://github.com/modbus2mqtt/server.shared/tree/v0.13.10) (2024-12-22)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.5...v0.13.6)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.9...v0.13.10)
 
-## [v0.13.5](https://github.com/volkmarnissen/server.shared/tree/v0.13.5) (2024-10-16)
+## [v0.13.9](https://github.com/modbus2mqtt/server.shared/tree/v0.13.9) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.4...v0.13.5)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.10.8...v0.13.9)
 
-## [v0.13.4](https://github.com/volkmarnissen/server.shared/tree/v0.13.4) (2024-10-14)
+## [v0.10.8](https://github.com/modbus2mqtt/server.shared/tree/v0.10.8) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.3...v0.13.4)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.8...v0.10.8)
 
-## [v0.13.3](https://github.com/volkmarnissen/server.shared/tree/v0.13.3) (2024-10-08)
+## [v0.13.8](https://github.com/modbus2mqtt/server.shared/tree/v0.13.8) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.1...v0.13.3)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.7...v0.13.8)
 
-## [v0.13.1](https://github.com/volkmarnissen/server.shared/tree/v0.13.1) (2024-09-16)
+## [v0.13.7](https://github.com/modbus2mqtt/server.shared/tree/v0.13.7) (2024-11-14)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.13.0...v0.13.1)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.6...v0.13.7)
 
-## [v0.13.0](https://github.com/volkmarnissen/server.shared/tree/v0.13.0) (2024-08-16)
+## [v0.13.6](https://github.com/modbus2mqtt/server.shared/tree/v0.13.6) (2024-10-22)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.12.0...v0.13.0)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.5...v0.13.6)
 
-## [v0.12.0](https://github.com/volkmarnissen/server.shared/tree/v0.12.0) (2024-08-05)
+## [v0.13.5](https://github.com/modbus2mqtt/server.shared/tree/v0.13.5) (2024-10-16)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/v0.11.0...v0.12.0)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.4...v0.13.5)
 
-## [v0.11.0](https://github.com/volkmarnissen/server.shared/tree/v0.11.0) (2024-08-04)
+## [v0.13.4](https://github.com/modbus2mqtt/server.shared/tree/v0.13.4) (2024-10-14)
 
-[Full Changelog](https://github.com/volkmarnissen/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.3...v0.13.4)
+
+## [v0.13.3](https://github.com/modbus2mqtt/server.shared/tree/v0.13.3) (2024-10-08)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.1...v0.13.3)
+
+## [v0.13.1](https://github.com/modbus2mqtt/server.shared/tree/v0.13.1) (2024-09-16)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.13.0...v0.13.1)
+
+## [v0.13.0](https://github.com/modbus2mqtt/server.shared/tree/v0.13.0) (2024-08-16)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.12.0...v0.13.0)
+
+## [v0.12.0](https://github.com/modbus2mqtt/server.shared/tree/v0.12.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/v0.11.0...v0.12.0)
+
+## [v0.11.0](https://github.com/modbus2mqtt/server.shared/tree/v0.11.0) (2024-08-04)
+
+[Full Changelog](https://github.com/modbus2mqtt/server.shared/compare/2c1cc3775e8a5139ccc3c99852a71f5d7e7046b3...v0.11.0)
 
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export interface Iconfiguration {
   supervisor_host?: string
   debugComponents?: string
   tcpBridgePort?: number
+  displayHex?:boolean
 }
 export enum AuthenticationErrors {
   EnvironmentVariableSecretNotSet = 1,


### PR DESCRIPTION
Enable Display and Input in Hex format for modbus Addresses
### Dependant Pullrequests
|Repository|Pull Request|
|----|----|
|[server.shared](https://github.com/modbus2mqtt/server.shared/pull/7)|7|
|[angular](https://github.com/modbus2mqtt/angular/pull/14)|14|
